### PR TITLE
Fix grace period: resolve OHTTP key ID in /app/key endpoint

### DIFF
--- a/src/endpoints/keyEndpoint.ts
+++ b/src/endpoints/keyEndpoint.ts
@@ -104,6 +104,52 @@ const requestHasWrappingKey = (
 };
 
 //#region KMS Key endpoints
+
+// Mirror of the data-plane's ToOhttpKeyId(): interpret the first two
+// characters of the (stringified) KMS key id as hex and pack into one byte.
+// Exported for unit testing.
+export function toOhttpKeyId(kmsKeyId: number | string): number | undefined {
+  const s = String(kmsKeyId);
+  if (s.length < 2) return undefined;
+  const hi = parseInt(s[0], 16);
+  const lo = parseInt(s[1], 16);
+  if (Number.isNaN(hi) || Number.isNaN(lo)) return undefined;
+  return (hi << 4) | lo;
+}
+
+// Resolve the `kid` query param to a wrappedKid.
+//  - Non-numeric kid  -> assume it is already a wrappedKid (back-compat).
+//  - Numeric kid      -> treat as an OHTTP id; scan keys newest-first and
+//                        return the wrappedKid whose keyItem.id maps to it.
+// Returns undefined when a numeric id matches no stored key; the `key`
+// endpoint turns that into a 404. Exported for unit testing.
+export function resolveKidQueryParam(
+  kidParam: string,
+  logContext: LogContext,
+): string | undefined {
+  if (!/^\d+$/.test(kidParam)) {
+    return kidParam;
+  }
+
+  const requestedOhttpId = Number(kidParam);
+  for (let id = hpkeKeyIdMap.size; id >= 1; id--) {
+    const wrappedKid = hpkeKeyIdMap.store.get(id);
+    if (wrappedKid === undefined) continue;
+
+    const keyItem = hpkeKeysMap.store.get(wrappedKid) as IKeyItem | undefined;
+    if (keyItem === undefined || typeof keyItem.id !== "number") continue;
+
+    if (toOhttpKeyId(keyItem.id) === requestedOhttpId) {
+      Logger.debug(
+        `Resolved OHTTP kid ${kidParam} -> wrappedKid ${wrappedKid} (keyItem.id=${keyItem.id})`,
+        logContext,
+      );
+      return wrappedKid;
+    }
+  }
+  return undefined;
+}
+
 // Get latest private key
 export const key = (
   request: ccfapp.Request<IKeyRequest>,
@@ -136,6 +182,7 @@ export const key = (
   let kid = serviceRequest.query?.["kid"];
   let id: number | undefined;
   if (kid === undefined) {
+    // No kid requested: return the latest key (unchanged behavior).
     [id, kid] = hpkeKeyIdMap.latestItem();
     if (kid === undefined) {
       return ServiceResult.Failed<string>(
@@ -144,6 +191,18 @@ export const key = (
         logContext
       );
     }
+  } else {
+    // A kid was requested. It may be a numeric OHTTP id (from the data-plane's
+    // by-id private key fetch) or an explicit wrappedKid. Resolve it.
+    const resolvedKid = resolveKidQueryParam(String(kid), logContext);
+    if (resolvedKid === undefined) {
+      return ServiceResult.Failed<string>(
+        { errorMessage: `${name}: kid ${kid} not found in store` },
+        404,
+        logContext
+      );
+    }
+    kid = resolvedKid;
   }
 
   const fmt = serviceRequest.query?.["fmt"] || "jwk";

--- a/test/unit-test/endpoints/keyEndpoint.test.ts
+++ b/test/unit-test/endpoints/keyEndpoint.test.ts
@@ -1,0 +1,67 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+// Use the CCF polyfill to mock-up all key-value map functionality for unit-test
+import "@microsoft/ccf-app/polyfill.js";
+import { beforeAll, describe, expect, test } from "@jest/globals";
+import { KeyGeneration, resolveKidQueryParam, toOhttpKeyId } from "../../../src";
+import { hpkeKeyIdMap, hpkeKeysMap } from "../../../src/repositories/Maps";
+import { LogContext } from "../../../src/utils/Logger";
+
+// Seeds one HPKE key into the stores the same way refreshEndpoint does:
+//   hpkeKeyIdMap:  sequential index -> wrappedKid
+//   hpkeKeysMap:   wrappedKid       -> keyItem (keyItem.id is the 2-digit id)
+// We set the maps directly (bypassing storeItem) to keep the unit test focused
+// on resolution logic rather than CCF claims/receipts.
+function seedKey(index: number, keyItemId: number, wrappedKid: string): void {
+  const keyItem = KeyGeneration.generateKeyItem(keyItemId);
+  keyItem.kid = wrappedKid;
+  hpkeKeysMap.store.set(wrappedKid, keyItem);
+  hpkeKeyIdMap.store.set(index, wrappedKid);
+}
+
+describe("keyEndpoint kid resolution", () => {
+  const logContext = new LogContext().appendScope("keyEndpoint.test");
+
+  // Two keys. Their on-the-wire OHTTP id is ToOhttpKeyId(keyItem.id), i.e. the
+  // 2-digit id read as hex:
+  //   id 26 -> 0x26 = 38   (matches production logs: keyItem.id 26 -> OHTTP 38)
+  //   id 30 -> 0x30 = 48
+  beforeAll(() => {
+    seedKey(1, 26, "wrappedKidAlpha_1");
+    seedKey(2, 30, "wrappedKidBeta_2");
+  });
+
+  test("toOhttpKeyId reads the 2-digit id as hex", () => {
+    expect(toOhttpKeyId(26)).toEqual(38);
+    expect(toOhttpKeyId(30)).toEqual(48);
+    expect(toOhttpKeyId("26")).toEqual(38);
+    // Too short to be a valid OHTTP-compatible id.
+    expect(toOhttpKeyId(5)).toBeUndefined();
+  });
+
+  test("numeric OHTTP id resolves to the matching wrappedKid", () => {
+    // Client/data-plane sends the OHTTP id "38"; it must map back to the
+    // wrappedKid of the key whose keyItem.id is 26.
+    expect(resolveKidQueryParam("38", logContext)).toEqual("wrappedKidAlpha_1");
+    expect(resolveKidQueryParam("48", logContext)).toEqual("wrappedKidBeta_2");
+  });
+
+  test("non-numeric wrappedKid passes through unchanged", () => {
+    // An explicit wrappedKid (base64url + _index, never all-digits) must be
+    // returned as-is for backward compatibility.
+    expect(resolveKidQueryParam("wrappedKidBeta_2", logContext)).toEqual(
+      "wrappedKidBeta_2",
+    );
+    // Pass-through does not require the kid to exist in the store.
+    expect(resolveKidQueryParam("some_unknown_wrappedKid", logContext)).toEqual(
+      "some_unknown_wrappedKid",
+    );
+  });
+
+  test("unknown numeric id resolves to undefined (endpoint returns 404)", () => {
+    // No seeded key maps to OHTTP id 99, so resolution fails. The `key`
+    // endpoint converts this undefined into a 404 "kid not found in store".
+    expect(resolveKidQueryParam("99", logContext)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
- Add toOhttpKeyId() helper mirroring data-plane ToOhttpKeyId()
- Add resolveKidQueryParam() to bridge OHTTP decimal IDs to wrappedKids
- Update /app/key endpoint to resolve numeric kid before store lookup
- Returns clean 404 when kid does not match any known key
- Backward compatible: non-numeric wrappedKids pass through unchanged
- Add unit tests for resolver covering all three cases