### PR TITLE
Grace period fix

### DIFF
--- a/.github/workflows/acl-app-update.yml
+++ b/.github/workflows/acl-app-update.yml
@@ -43,7 +43,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: "20"
-          cache: npm
 
       - name: Install runner prerequisites
         run: |

--- a/app.json
+++ b/app.json
@@ -298,6 +298,11 @@
             "in": "query",
             "name": "fmt",
             "required": false
+          },
+          {
+            "in": "query",
+            "name": "all",
+            "required": false
           }
         ],
         "openapi": {

--- a/scripts/kms/endpoints/key.sh
+++ b/scripts/kms/endpoints/key.sh
@@ -20,6 +20,10 @@ key() {
                 params+=("fmt=$2")
                 shift 2
                 ;;
+            --all)
+                params+=("all=$2")
+                shift 2
+                ;;
             --attestation)
                 attestation="$2"
                 shift 2

--- a/src/endpoints/KeyWrapper.ts
+++ b/src/endpoints/KeyWrapper.ts
@@ -162,11 +162,11 @@ export class KeyWrapper {
     return wrappedB64;
   };
 
-  // Create an EncryptionKey structure of a tink key
-  public static wrapKeyTink = (
+  // Build a single EncryptionKey structure for a tink key.
+  private static buildEncryptionKey = (
     wrappingKey: ArrayBuffer | undefined,
     payload: IKeyItem,
-  ): IWrapped => {
+  ): EncryptionKey => {
     const encryptionKey: EncryptionKey = {
       // The following id will be treated as keyId.
       // We need to figure out the exact format.
@@ -209,7 +209,32 @@ export class KeyWrapper {
       ],
     };
     Logger.debug(`Encryption public key: `, encryptionKey);
-    const ret: IWrapped = { keys: [encryptionKey] };
+    return encryptionKey;
+  };
+
+  // Create an EncryptionKey structure of a tink key
+  public static wrapKeyTink = (
+    wrappingKey: ArrayBuffer | undefined,
+    payload: IKeyItem,
+  ): IWrapped => {
+    const ret: IWrapped = {
+      keys: [KeyWrapper.buildEncryptionKey(wrappingKey, payload)],
+    };
+    return ret;
+  };
+
+  // Create an IWrapped structure containing multiple tink keys. Used to release
+  // the full set of currently-valid (non-expired) private keys in a single
+  // response so that services can cache every key a client might still be using.
+  public static wrapKeysTink = (
+    wrappingKey: ArrayBuffer | undefined,
+    payloads: IKeyItem[],
+  ): IWrapped => {
+    const ret: IWrapped = {
+      keys: payloads.map((payload) =>
+        KeyWrapper.buildEncryptionKey(wrappingKey, payload),
+      ),
+    };
     return ret;
   };
 

--- a/src/endpoints/keyEndpoint.ts
+++ b/src/endpoints/keyEndpoint.ts
@@ -194,10 +194,53 @@ export const key = (
     return ServiceResult.Accepted(logContext);
   }
 
+  // When the caller did not ask for a specific kid and requests all keys
+  // (?all=true), return every currently-valid (non-expired) private key so a
+  // service can cache each key a client might still be using during a key
+  // rotation grace period. Only supported for the tink format used by services.
+  const listAll =
+    serviceRequest.query?.["all"] === "true" &&
+    serviceRequest.query?.["kid"] === undefined;
+  if (listAll && fmt !== "tink") {
+    return ServiceResult.Failed<string>(
+      { errorMessage: `${name}: all=true requires fmt=tink` },
+      400,
+      logContext
+    );
+  }
+
   // Get wrapped key
   try {
     let wrapped: string | IWrapped;
-    if (fmt == "tink") {
+    if (listAll) {
+      // Collect all non-expired keys, ordered oldest to newest.
+      const validKeyItems: IKeyItem[] = [];
+      for (let keyId = 1; keyId <= hpkeKeyIdMap.size; keyId++) {
+        const itemKid = hpkeKeyIdMap.store.get(keyId);
+        if (itemKid === undefined) continue;
+        const item = hpkeKeysMap.store.get(itemKid) as IKeyItem;
+        if (item === undefined) continue;
+        const [expired] = KeyRotationPolicy.isExpired(
+          keyRotationPolicyMap,
+          item,
+          logContext
+        );
+        if (expired) continue;
+        validKeyItems.push(item);
+      }
+      if (validKeyItems.length === 0) {
+        return ServiceResult.Failed<string>(
+          { errorMessage: `${name}: No valid keys in store` },
+          404,
+          logContext
+        );
+      }
+      Logger.debug(
+        `Returning ${validKeyItems.length} valid key(s) for all=true request`,
+        logContext
+      );
+      wrapped = JSON.stringify(KeyWrapper.wrapKeysTink(undefined, validKeyItems));
+    } else if (fmt == "tink") {
       wrapped = KeyWrapper.wrapKeyTink(undefined, keyItem);
       wrapped = JSON.stringify(wrapped);
     } else {

--- a/test/system-test/test_keyRotationPolicy.py
+++ b/test/system-test/test_keyRotationPolicy.py
@@ -255,6 +255,56 @@ def test_key_rotation_public_key_exposure_delay(setup_kms_session):
     )
 
 
+def test_key_all_returns_all_valid_keys(setup_kms_session):
+    """Verify /key?all=true returns every currently-valid (non-expired) private
+    key in the wrapped `keys` array, so a service launched during a rotation
+    grace period can cache each key a client might still be using."""
+    apply_settings_policy()
+    apply_key_release_policy()
+    # Long rotation interval so both keys created below stay valid (non-expired).
+    rotation_policy = {
+        "actions": [
+            {
+                "name": "set_key_rotation_policy",
+                "args": {
+                    "key_rotation_policy": {
+                        "rotation_interval_seconds": 3600,
+                        "grace_period_seconds": 5,
+                    }
+                },
+            }
+        ]
+    }
+    apply_key_rotation_policy(rotation_policy)
+
+    # Create two keys.
+    refresh()
+    refresh()
+
+    # Request all valid keys (fmt=tink is required for the keys[] format).
+    while True:
+        status_code, all_keys_resp = key(
+            attestation=get_test_attestation(),
+            wrapping_key=get_test_public_wrapping_key(),
+            fmt="tink",
+            all="true",
+        )
+        if status_code != 202:
+            break
+    assert status_code == 200
+
+    wrapped = json.loads(all_keys_resp["wrapped"])
+    assert "keys" in wrapped, f"Expected 'keys' array in wrapped, got {wrapped}"
+    # At least the two keys created above must be present.
+    assert len(wrapped["keys"]) >= 2, (
+        f"Expected >= 2 valid keys, got {len(wrapped['keys'])}"
+    )
+    # Each entry must be a well-formed encryption key with its own kid.
+    for entry in wrapped["keys"]:
+        assert entry["name"].startswith("encryptionKeys/")
+        assert entry["keyData"][0]["keyEncryptionKeyUri"].startswith("azu-kms://")
+
+
 if __name__ == "__main__":
     import pytest
 


### PR DESCRIPTION
## Summary
`POST /app/key?fmt=tink&all=true` now returns every currently-valid (non-expired) private key, not just the latest. This lets a service launched during a rotation grace period cache the previous keys as well as the new one, so it can decrypt traffic still encrypted with the publicly-exposed key.

Public-key endpoints (`/pubkey`, `/listpubkeys`) are unchanged: they still lag by `grace_period_seconds` via `getLatestExposableKey`, in order to prevent any mismatch during key rotation.

## Why
When keys rotate weekly as per the [Refresh Keys](https://github.com/iSPIRT/azure-depa-inferencing-kms/actions/workflows/acl-refresh.yml) workflow, there will be a key mismatch window which may last up to the duration of the CCR services' private-key cache interval (i.e. 3h). To prevent this, a grace period is introduced with a time period as set in the [Key Rotation Policy](https://github.com/iSPIRT/azure-depa-inferencing-kms/blob/main/governance/policies/key-rotation-policy.json), which allows all services to continue using the previous key during the rotation window while also transitioning to the newly rotated key. This ensures that a service launched during the grace period can fetch and cache both the previous and new private keys, allowing it to decrypt traffic encrypted with either key.

## Behavior
- No `all` / no `kid`: latest key only (unchanged).
- `all=true` (no `kid`, `fmt=tink`): all keys with `now < creationTime + rotation_interval_seconds` (currently 31 days).
- Explicit `kid`: that key only (unchanged).
- Expired keys (`isExpired` / `expiryTimeMs`) are skipped.

## Compatibility
In order for this to work, the [data-plane libraries](https://github.com/iSPIRT/ad-selection-api.data-plane-shared-libraries) must implement the equivalent fix to make the updated call to fetch all valid keys. (See [PR #11](https://github.com/iSPIRT/ad-selection-api.data-plane-shared-libraries/pull/11))

Note: Only Offer Frontend and Offer Generation service versions>=4.8.3.0 and Key Value service>=1.2.3.0 contain the required data-plane fix for the grace period. (See [PR #113](https://github.com/iSPIRT/depa-inferencing/pull/113))